### PR TITLE
API for ETL of Tables to GCP

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+GOOGLE_APPLICATION_CREDENTIALS=credentials/data-project.json
+GCP_PROJECT_ID=data-project-452300
+BQ_DATASET=globant

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 credentials/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-data-project.json
+credentials/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,9 @@ COPY . /app
 RUN pip install --no-cache-dir -r requirements.txt
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+
+
+# Copiar o arquivo .env e a credencial
+COPY .env .env
+COPY credentials/ credentials/
+ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/data-project.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM python:3.11-slim
 
 WORKDIR /app
+
+# Copy all project files into the container
 COPY . /app
 
-# Copia o .env e as credenciais
+# Copy environment variables and service account credentials
 COPY .env .env
 COPY credentials/ credentials/
 
-# Define a variável de ambiente usada pela SDK
+# Set the environment variable for GCP authentication
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/data-project.json
 
+# Install all Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Start the FastAPI application using Uvicorn
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY . /app
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
-
-
-# Copiar o arquivo .env e a credencial
+# Copia o .env e as credenciais
 COPY .env .env
 COPY credentials/ credentials/
+
+# Define a variável de ambiente usada pela SDK
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/data-project.json
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,18 @@ WORKDIR /app
 # Copy all project files into the container
 COPY . /app
 
-# Copy environment variables and service account credentials
-COPY .env .env
-COPY credentials/ credentials/
-
-# Set the environment variable for GCP authentication
+# Set environment variables
+ENV PYTHONPATH=/app
 ENV GOOGLE_APPLICATION_CREDENTIALS=/app/credentials/data-project.json
 
-# Install all Python dependencies
+# Install system dependencies including curl
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Start the FastAPI application using Uvicorn
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Make start script executable
+RUN chmod +x /app/start.sh
+
+# Run the start script to launch the API and upload CSVs
+CMD ["/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # data-engineering-case-globant
+
+
+
+
+Uvicorn host: http://127.0.0.1:8000/redoc

--- a/app/bq.py
+++ b/app/bq.py
@@ -1,11 +1,10 @@
 from google.cloud import bigquery
 import os
+from dotenv import load_dotenv
+
+load_dotenv()  # Carrega as variáveis do .env
 
 PROJECT_ID = os.getenv("GCP_PROJECT_ID")
 DATASET = os.getenv("BQ_DATASET")
 
 client = bigquery.Client()
-
-
-def get_table_ref(table_name: str):
-    return f"{PROJECT_ID}.{DATASET}.{table_name}"

--- a/app/bq.py
+++ b/app/bq.py
@@ -2,9 +2,14 @@ from google.cloud import bigquery
 import os
 from dotenv import load_dotenv
 
-load_dotenv()  # Carrega as variáveis do .env
+# Load environment variables from .env file
+load_dotenv()
 
 PROJECT_ID = os.getenv("GCP_PROJECT_ID")
 DATASET = os.getenv("BQ_DATASET")
 
 client = bigquery.Client()
+
+
+def get_table_ref(table_name: str):
+    return f"{PROJECT_ID}.{DATASET}.{table_name}"

--- a/app/load.py
+++ b/app/load.py
@@ -1,0 +1,40 @@
+import pandas as pd
+from fastapi import UploadFile
+from app.bq import client, get_table_ref
+
+schema_map = {
+    "departments": ["id", "department"],
+    "jobs": ["id", "job"],
+    "hired_employees": ["id", "name", "datetime", "department_id", "job_id"],
+}
+
+
+def load_csv_to_bigquery(file: UploadFile, table_name: str):
+    try:
+        expected_columns = schema_map.get(table_name)
+        if not expected_columns:
+            return {"status": "failed", "error": f"Unknown table '{table_name}'"}
+
+        df = pd.read_csv(file.file, names=expected_columns, header=None)
+
+        table_id = get_table_ref(table_name)
+        job = client.load_table_from_dataframe(df, table_id)
+        job.result()
+
+        return {"status": "success", "rows": len(df)}
+
+    except Exception as e:
+        return {"status": "failed", "error": str(e)}
+
+
+def insert_batch_rows(rows: list[dict], table_name: str):
+    if not rows:
+        return {"status": "failed", "reason": "No rows provided."}
+    if len(rows) > 1000:
+        return {"status": "failed", "reason": "Batch limit exceeded (max 1000)."}
+
+    table_id = get_table_ref(table_name)
+    errors = client.insert_rows_json(table_id, rows)
+    if errors:
+        return {"status": "failed", "errors": errors}
+    return {"status": "success", "rows_inserted": len(rows)}

--- a/app/load.py
+++ b/app/load.py
@@ -1,22 +1,70 @@
 import pandas as pd
-from fastapi import UploadFile
 from app.bq import client, get_table_ref
+from fastapi import UploadFile
+from google.cloud import bigquery
 
 schema_map = {
-    "departments": ["id", "department"],
-    "jobs": ["id", "job"],
-    "hired_employees": ["id", "name", "datetime", "department_id", "job_id"],
+    "departments": [
+        bigquery.SchemaField("id", "INTEGER"),
+        bigquery.SchemaField("department", "STRING"),
+    ],
+    "jobs": [
+        bigquery.SchemaField("id", "INTEGER"),
+        bigquery.SchemaField("job", "STRING"),
+    ],
+    "hired_employees": [
+        bigquery.SchemaField("id", "INTEGER"),
+        bigquery.SchemaField("name", "STRING"),
+        bigquery.SchemaField("datetime", "TIMESTAMP"),
+        bigquery.SchemaField("department_id", "INTEGER"),
+        bigquery.SchemaField("job_id", "INTEGER"),
+    ],
 }
+
+
+def recreate_table(table_name: str):
+    table_id = get_table_ref(table_name)
+    try:
+        client.delete_table(table_id, not_found_ok=True)
+        print(f"[INFO] Deleted existing table: {table_id}")
+    except Exception as e:
+        print(f"[WARN] Could not delete table {table_id}: {e}")
+    table = bigquery.Table(table_id, schema=schema_map[table_name])
+    client.create_table(table)
+    print(f"[INFO] Recreated table: {table_id}")
 
 
 def load_csv_to_bigquery(file: UploadFile, table_name: str):
     try:
-        expected_columns = schema_map.get(table_name)
-        if not expected_columns:
-            return {"status": "failed", "error": f"Unknown table '{table_name}'"}
+        # Recreate the destination table
+        recreate_table(table_name)
 
-        df = pd.read_csv(file.file, names=expected_columns, header=None)
+        # Read and format the CSV
 
+        df = pd.read_csv(file.file, header=None)
+        df.columns = [field.name for field in schema_map[table_name]]
+
+        # Force correct column types
+        if table_name == "hired_employees":
+            df.columns = ["id", "name", "datetime", "department_id", "job_id"]
+
+            # Remove lines with missing key columns
+            df.dropna(
+                subset=["id", "department_id", "job_id", "datetime"], inplace=True
+            )
+
+            df["id"] = df["id"].astype(int)
+            df["department_id"] = df["department_id"].astype(int)
+            df["job_id"] = df["job_id"].astype(int)
+            df["datetime"] = pd.to_datetime(df["datetime"], errors="coerce")
+
+        if table_name == "departments":
+            df["id"] = df["id"].astype(int)
+
+        if table_name == "jobs":
+            df["id"] = df["id"].astype(int)
+
+        # Upload to BigQuery
         table_id = get_table_ref(table_name)
         job = client.load_table_from_dataframe(df, table_id)
         job.result()

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, UploadFile, File
+from app.load import load_csv_to_bigquery
 
 app = FastAPI()
 
@@ -6,3 +7,8 @@ app = FastAPI()
 @app.get("/")
 def root():
     return {"message": "API is up"}
+
+
+@app.post("/upload_csv/")
+async def upload_csv(file: UploadFile = File(...), table_name: str = "hired_employees"):
+    return load_csv_to_bigquery(file, table_name)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,45 @@
+"""
+Waits for the API to be ready
+
+Automatically sends the necessary data (CSV files)
+
+Prepares the environment so the system is ready to use without any manual step
+"""
+
+import time
+import requests
+
+files_to_upload = [
+    ("departments", "data/departments.csv"),
+    ("jobs", "data/jobs.csv"),
+    ("hired_employees", "data/hired_employees.csv"),
+]
+
+
+def wait_for_api(url, timeout=30):
+    for _ in range(timeout):
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                print("API is up.")
+                return True
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+    print("ERORR: API did not start in time.")
+    return False
+
+
+def upload_csv(table_name, filepath):
+    with open(filepath, "rb") as f:
+        files = {"file": (filepath, f)}
+        res = requests.post(
+            f"http://localhost:8080/upload_csv/?table_name={table_name}", files=files
+        )
+        print(f"Uploading {filepath} to {table_name} → {res.status_code} | {res.text}")
+
+
+if __name__ == "__main__":
+    if wait_for_api("http://localhost:8080/"):
+        for table_name, filepath in files_to_upload:
+            upload_csv(table_name, filepath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,6 @@ fastapi
 uvicorn[standard]
 sqlalchemy
 asyncpg
+pyarrow
 
+python-multipart

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Start the FastAPI API in the background
+uvicorn app.main:app --host 0.0.0.0 --port 8080 &
+
+# Wait for the API to be up
+echo "[BOOTSTRAP] Waiting for API to be ready..."
+until curl -s http://localhost:8080/ > /dev/null; do
+  sleep 1
+done
+echo "[BOOTSTRAP] API is up. Sending CSVs..."
+
+# Upload CSVs via API (one-time load)
+curl -X POST "http://localhost:8080/upload_csv/?table_name=departments" -F "file=@data/departments.csv"
+curl -X POST "http://localhost:8080/upload_csv/?table_name=jobs" -F "file=@data/jobs.csv"
+curl -X POST "http://localhost:8080/upload_csv/?table_name=hired_employees" -F "file=@data/hired_employees.csv"
+
+# Keep the container alive
+wait


### PR DESCRIPTION
Section 1: API

In the context of a DB migration with 3 different tables (departments, jobs, employees) , create
a local REST API that must:
1. Receive historical data from CSV files
2. Upload these files to the new DB
3. Be able to insert batch transactions (1 up to 1000 rows) with one request
